### PR TITLE
Add support to non-ascii characters.

### DIFF
--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -115,7 +115,7 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
           unless value.nil?
             matched = true
             event[xpath_dest] ||= []
-            event[xpath_dest] << value.to_s
+            event[xpath_dest] << value.to_str
           end
         end # XPath.each
       end # @xpath.each


### PR DESCRIPTION
The to_str instead to_s function make it possible to use non-ascii characters.
