### PR TITLE
Require 'target' option to be set if 'store_xml' is true

### DIFF
--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -92,6 +92,15 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
   def register
     require "nokogiri"
     require "xmlsimple"
+
+    if @store_xml && (!@target || @target.empty?)
+      raise LogStash::ConfigurationError, I18n.t(
+        "logstash.agent.configuration.invalid_plugin_register",
+        :plugin => "filter",
+        :type => "xml",
+        :error => "When the 'store_xml' configuration option is true, 'target' must also be set"
+      )
+    end
   end
 
   def filter(event)

--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -209,6 +209,7 @@ describe LogStash::Filters::Xml do
         source => "xmldata"
         xpath => [ "/foo/h:div", "xpath_field" ]
         remove_namespaces => false
+        store_xml => false
       }
     }
     CONFIG
@@ -227,6 +228,7 @@ describe LogStash::Filters::Xml do
           xpath => [ "/foo/h:div", "xpath_field" ]
           namespaces => {"h" => "http://www.w3.org/TR/html4/"}
           remove_namespaces => false
+          store_xml => false
         }
       }
       CONFIG
@@ -245,6 +247,7 @@ describe LogStash::Filters::Xml do
           xpath => [ "/foo/h:div", "xpath_field" ]
           namespaces => {"h" => "http://www.w3.org/TR/html4/"}
           remove_namespaces => false
+          store_xml => false
         }
       }
       CONFIG
@@ -262,6 +265,7 @@ describe LogStash::Filters::Xml do
         source => "xmldata"
         xpath => [ "/foo/div", "xpath_field" ]
         remove_namespaces => true
+        store_xml => false
       }
     }
     CONFIG
@@ -303,6 +307,21 @@ describe LogStash::Filters::Xml do
     # Single value
     sample("xmldata" => '<foo><bar>Content</bar></foo>') do
       insist { subject.get("parseddata") } == { "bar" => "Content" }
+    end
+  end
+
+  describe "plugin registration" do
+    config <<-CONFIG
+    filter {
+      xml {
+        xmldata => "message"
+        store_xml => true
+      }
+    }
+    CONFIG
+
+    sample("xmldata" => "<foo>random message</foo>") do
+      insist { subject }.raises(LogStash::ConfigurationError)
     end
   end
 end


### PR DESCRIPTION
Unless `store_xml` is disabled, the `target` option must be set to a non-empty string so the plugin knows where to store the parsed XML. Previously this invariant wasn't checked so the subsequent field assignment raised a NoMethodError. This was treated as if the XML parsing failed, resulting in the addition of a `_xmlparsefailure` tag even though the XML was perfectly fine. Fixes #9.