### PR TITLE
4.1.0 improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.1.0
+ - bugfix: catch xpath-expression syntax error instead of impacting pipeline. Fix #19
+ - bugfix: report xml parsing error when parsing only with xpath and store_xml => false (using Nokogiri internally). Fix #10
+ - config: allow to create xpath-expression from event data using dynamic syntax
+ - config: fail at startup if store_xml => false and no xpath config specified, as the filter would do nothing
+ - internal: do not parse document with Nokogiri when xpath contains no expressions
+ - internal: restructure tests using contexts
+
 ## 4.0.0
   - breaking,config: New configuration `suppress_empty`. Default to true change default behaviour of the plugin in favor of avoiding mapping conflicts when reaching elasticsearch
   - config: New configuration `force_content`. By default the filter expands attributes differently from content in xml elements.

--- a/logstash-filter-xml.gemspec
+++ b/logstash-filter-xml.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-xml'
-  s.version         = '4.0.0'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Takes a field that contains XML and expands it into an actual datastructure."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -4,113 +4,93 @@ require "logstash/filters/xml"
 
 describe LogStash::Filters::Xml do
 
-  describe "parse standard xml (Deprecated checks)" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "raw"
-        target => "data"
-      }
-    }
-    CONFIG
+  # Common tests to validate behaviour of used xml parsing library
+  RSpec.shared_examples "report _xmlparsefailure" do |config_string|
 
-    sample("raw" => '<foo key="value"/>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("data")} == {"key" => "value"}
-    end
+    describe "parsing standard xml (Deprecated checks)" do
+      config(config_string)
 
-    #From parse xml with array as a value
-    sample("raw" => '<foo><key>value1</key><key>value2</key></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("data")} == {"key" => ["value1", "value2"]}
-    end
+      sample("xmldata" => '<foo key="value"/>') do
+        insist { subject.get("tags") }.nil?
+      end
 
-    #From parse xml with hash as a value
-    sample("raw" => '<foo><key1><key2>value</key2></key1></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("data")} == {"key1" => [{"key2" => ["value"]}]}
-    end
+      #From parse xml with array as a value
+      sample("xmldata" => '<foo><key>value1</key><key>value2</key></foo>') do
+        insist { subject.get("tags") }.nil?
+      end
 
-    # parse xml in single item array
-    sample("raw" => ["<foo bar=\"baz\"/>"]) do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("data")} == {"bar" => "baz"}
-    end
+      #From parse xml with hash as a value
+      sample("xmldata" => '<foo><key1><key2>value</key2></key1></foo>') do
+        insist { subject.get("tags") }.nil?
+      end
 
-    # fail in multi items array
-    sample("raw" => ["<foo bar=\"baz\"/>", "jojoba"]) do
-      insist { subject.get("tags") }.include?("_xmlparsefailure")
-      insist { subject.get("data")} == nil
-    end
+      # parse xml in single item array
+      sample("xmldata" => ["<foo bar=\"baz\"/>"]) do
+        insist { subject.get("tags") }.nil?
+      end
 
-    # fail in empty array
-    sample("raw" => []) do
-      insist { subject.get("tags") }.include?("_xmlparsefailure")
-      insist { subject.get("data")} == nil
-    end
+      # fail in multi items array
+      sample("xmldata" => ["<foo bar=\"baz\"/>", "jojoba"]) do
+        insist { subject.get("tags") }.include?("_xmlparsefailure")
+        insist { subject.get("data")} == nil
+      end
 
-    # fail for non string field
-    sample("raw" => {"foo" => "bar"}) do
-      insist { subject.get("tags") }.include?("_xmlparsefailure")
-      insist { subject.get("data")} == nil
-    end
+      # fail in empty array
+      sample("xmldata" => []) do
+        insist { subject.get("tags") }.include?("_xmlparsefailure")
+        insist { subject.get("data")} == nil
+      end
 
-    # fail for non string single item array
-    sample("raw" => [{"foo" => "bar"}]) do
-      insist { subject.get("tags") }.include?("_xmlparsefailure")
-      insist { subject.get("data")} == nil
-    end
+      # fail for non string field
+      sample("xmldata" => {"foo" => "bar"}) do
+        insist { subject.get("tags") }.include?("_xmlparsefailure")
+        insist { subject.get("data")} == nil
+      end
 
-    #From bad xml
-    sample("raw" => '<foo /') do
-      insist { subject.get("tags") }.include?("_xmlparsefailure")
+      # fail for non string single item array
+      sample("xmldata" => [{"foo" => "bar"}]) do
+        insist { subject.get("tags") }.include?("_xmlparsefailure")
+        insist { subject.get("data")} == nil
+      end
+
+      #From bad xml
+      sample("xmldata" => '<foo /') do
+        insist { subject.get("tags") }.include?("_xmlparsefailure")
+      end
     end
   end
 
-  describe "parse standard xml but do not store (Deprecated checks)" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "raw"
-        target => "data"
-        store_xml => false
-      }
-    }
-    CONFIG
+  context "ensure xml parsers consistent report of _xmlparsefailure" do
 
-    sample("raw" => '<foo key="value"/>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("data")} == nil
+    #XMLSimple only, when no xpath
+    context "XMLSimple validation" do
+      config_string = <<-CONFIG
+      filter {
+        xml {
+          source => "xmldata"
+          target => "data"
+        }
+      }
+      CONFIG
+      include_examples "report _xmlparsefailure", config_string
+    end
+
+    #Nokogiri only when xpath exists and store_xml => false
+    context "Nokogiri validation" do
+      config_string = <<-CONFIG
+      filter {
+        xml {
+          source => "xmldata"
+          store_xml => false
+          xpath => { "/" => nil }
+        }
+      }
+      CONFIG
+      include_examples "report _xmlparsefailure", config_string
     end
   end
 
-  describe "parse xml and store values with xpath (Deprecated checks)" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "raw"
-        target => "data"
-        xpath => [ "/foo/key/text()", "xpath_field" ]
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("raw" => '<foo><key>value</key></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("xpath_field")} == ["value"]
-    end
-
-    #Multiple values
-    sample("raw" => '<foo><key>value1</key><key>value2</key></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("xpath_field")} == ["value1","value2"]
-    end
-  end
-
-  ## New tests
-
-  describe "parse standard xml" do
+  context "parse standard xml" do
     config <<-CONFIG
     filter {
       xml {
@@ -137,264 +117,305 @@ describe LogStash::Filters::Xml do
       insist { subject.get("data") } == {"key1" => [{"key2" => ["value"]}]}
     end
 
-    #From bad xml
-    sample("xmldata" => '<foo /') do
-      insist { subject.get("tags") }.include?("_xmlparsefailure")
+    context "using formatting options" do
+      context "forcing_array" do
+        describe "enabled" do
+          config <<-CONFIG
+          filter {
+            xml {
+              source => "xmldata"
+              target => "parseddata"
+              force_array => true
+            }
+          }
+          CONFIG
+
+          # Single value
+          sample("xmldata" => '<foo><bar>Content</bar></foo>') do
+            insist { subject.get("parseddata") } == { "bar" => ["Content"] }
+          end
+        end
+
+        describe "disabled" do
+          config <<-CONFIG
+          filter {
+            xml {
+              source => "xmldata"
+              target => "parseddata"
+              force_array => false
+            }
+          }
+          CONFIG
+
+          # Single value
+          sample("xmldata" => '<foo><bar>Content</bar></foo>') do
+            insist { subject.get("parseddata") } == { "bar" => "Content" }
+          end
+        end
+      end
+
+      context "suppress_empty" do
+        describe "disabled" do
+          config <<-CONFIG
+          filter {
+            xml {
+              source => "xmldata"
+              target => "data"
+              suppress_empty => false
+            }
+          }
+          CONFIG
+
+          sample("xmldata" => '<foo><key>value1</key><key></key></foo>') do
+            insist { subject.get("tags") }.nil?
+            insist { subject.get("data") } == {"key" => ["value1", {}]}
+          end
+        end
+
+        describe "enabled" do
+          config <<-CONFIG
+          filter {
+            xml {
+              source => "xmldata"
+              target => "data"
+              suppress_empty => true
+            }
+          }
+          CONFIG
+
+          sample("xmldata" => '<foo><key>value1</key><key></key></foo>') do
+            insist { subject.get("tags") }.nil?
+            insist { subject.get("data") } == {"key" => ["value1"]}
+          end
+        end
+      end
+
+      context "force_content" do
+        describe "disabled" do
+          config <<-CONFIG
+          filter {
+            xml {
+              source => "xmldata"
+              target => "data"
+              force_array => false
+              force_content => false
+            }
+          }
+          CONFIG
+
+          sample("xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>') do
+            insist { subject.get("tags") }.nil?
+            insist { subject.get("data") } ==  { 'x' => 'text1', 'y' => { 'a' => '2', 'content' => 'text2' } }
+          end
+        end
+        describe "enabled" do
+          config <<-CONFIG
+          filter {
+            xml {
+              source => "xmldata"
+              target => "data"
+              force_array => false
+              force_content => true
+            }
+          }
+          CONFIG
+
+          sample("xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>') do
+            insist { subject.get("tags") }.nil?
+            insist { subject.get("data") } ==  { 'x' => { 'content' => 'text1' }, 'y' => { 'a' => '2', 'content' => 'text2' } }
+          end
+        end
+      end
     end
   end
 
-  describe "parse standard xml but do not store" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        target => "data"
-        store_xml => false
+  context "executing xpath query on the xml content and storing result in a field" do
+    context "standard usage" do
+      describe "parse xml and store values with xpath" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            store_xml => false
+            xpath => [ "/foo/key/text()", "xpath_field" ]
+          }
+        }
+        CONFIG
+
+        # Single value
+        sample("xmldata" => '<foo><key>value</key></foo>') do
+          insist { subject.get("tags") }.nil?
+          insist { subject.get("xpath_field") } == ["value"]
+        end
+
+        #Multiple values
+        sample("xmldata" => '<foo><key>value1</key><key>value2</key></foo>') do
+          insist { subject.get("tags") }.nil?
+          insist { subject.get("xpath_field") } == ["value1","value2"]
+        end
+      end
+
+      describe "parse correctly non ascii content with xpath" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            store_xml => false
+            xpath => [ "/foo/key/text()", "xpath_field" ]
+          }
+        }
+        CONFIG
+
+        # Single value
+        sample("xmldata" => '<foo><key>Français</key></foo>') do
+          insist { subject.get("tags") }.nil?
+          insist { subject.get("xpath_field")} == ["Français"]
+        end
+      end
+    end
+
+    context "xpath expression configuration" do
+
+      describe "report syntax error" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            target => "data"
+            xpath => [ "/foo/key/unknown-method()", "xpath_field" ]
+          }
+        }
+        CONFIG
+
+        sample("xmldata" => '<foo><key>Français</key></foo>') do
+          insist { subject.get("tags") } == ["_xpathsyntaxfailure"]
+        end
+      end
+
+      describe "retrieved from event field" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            target => "data"
+            xpath => [ "%{xpath_query}", "xpath_field" ]
+          }
+        }
+        CONFIG
+
+        sample("xmldata" => '<foo><key>Français</key></foo>', "xpath_query" => "/foo/key/text()") do
+          insist { subject.get("tags") }.nil?
+          insist { subject.get("xpath_field")} == ["Français"]
+        end
+      end
+    end
+
+    context "namespace handling" do
+      describe "parse including namespaces" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            xpath => [ "/foo/h:div", "xpath_field" ]
+            remove_namespaces => false
+            store_xml => false
+          }
+        }
+        CONFIG
+
+        # Single value
+        sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
+          insist { subject.get("xpath_field") } == ["<h:div>Content</h:div>"]
+        end
+      end
+
+      describe "parse including namespaces declarations on root" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            xpath => [ "/foo/h:div", "xpath_field" ]
+            namespaces => {"h" => "http://www.w3.org/TR/html4/"}
+            remove_namespaces => false
+            store_xml => false
+          }
+        }
+        CONFIG
+
+        # Single value
+        sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
+          insist { subject.get("xpath_field") } == ["<h:div>Content</h:div>"]
+        end
+      end
+
+      describe "parse including namespaces declarations on child" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            xpath => [ "/foo/h:div", "xpath_field" ]
+            namespaces => {"h" => "http://www.w3.org/TR/html4/"}
+            remove_namespaces => false
+            store_xml => false
+          }
+        }
+        CONFIG
+
+        # Single value
+        sample("xmldata" => '<foo><h:div xmlns:h="http://www.w3.org/TR/html4/">Content</h:div></foo>') do
+          insist { subject.get("xpath_field") } == ["<h:div xmlns:h=\"http://www.w3.org/TR/html4/\">Content</h:div>"]
+        end
+      end
+
+      describe "parse removing namespaces" do
+        config <<-CONFIG
+        filter {
+          xml {
+            source => "xmldata"
+            xpath => [ "/foo/div", "xpath_field" ]
+            remove_namespaces => true
+            store_xml => false
+          }
+        }
+        CONFIG
+
+        # Single value
+        sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
+          insist { subject.get("xpath_field") } == ["<div>Content</div>"]
+        end
+      end
+    end
+  end
+
+  context "plugin registration checks" do
+    describe "ensure target is set when store_xml => true" do
+      config <<-CONFIG
+      filter {
+        xml {
+          xmldata => "message"
+          store_xml => true
+        }
       }
-    }
-    CONFIG
+      CONFIG
 
-    sample("xmldata" => '<foo key="value"/>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("data")} == nil
-    end
-  end
-
-  describe "parse xml and store values with xpath" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        target => "data"
-        xpath => [ "/foo/key/text()", "xpath_field" ]
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("xmldata" => '<foo><key>value</key></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("xpath_field") } == ["value"]
+      sample("xmldata" => "<foo>random message</foo>") do
+        insist { subject }.raises(LogStash::ConfigurationError)
+      end
     end
 
-    #Multiple values
-    sample("xmldata" => '<foo><key>value1</key><key>value2</key></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("xpath_field") } == ["value1","value2"]
-    end
-  end
-
-  describe "parse correctly non ascii content with xpath" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        target => "data"
-        xpath => [ "/foo/key/text()", "xpath_field" ]
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("xmldata" => '<foo><key>Français</key></foo>') do
-      insist { subject.get("tags") }.nil?
-      insist { subject.get("xpath_field")} == ["Français"]
-    end
-  end
-
-  describe "parse including namespaces" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        xpath => [ "/foo/h:div", "xpath_field" ]
-        remove_namespaces => false
-        store_xml => false
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
-      insist { subject.get("xpath_field") } == ["<h:div>Content</h:div>"]
-    end
-  end
-
-  describe "parse including namespaces declarations on root" do
+    describe "ensure xpath is set when store_xml => false" do
       config <<-CONFIG
       filter {
         xml {
           source => "xmldata"
-          xpath => [ "/foo/h:div", "xpath_field" ]
-          namespaces => {"h" => "http://www.w3.org/TR/html4/"}
-          remove_namespaces => false
           store_xml => false
         }
       }
       CONFIG
 
-      # Single value
-      sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
-        insist { subject.get("xpath_field") } == ["<h:div>Content</h:div>"]
+      sample("xmldata" => "<foo>random message</foo>") do
+        insist { subject }.raises(LogStash::ConfigurationError)
       end
-  end
-
-  describe "parse including namespaces declarations on child" do
-      config <<-CONFIG
-      filter {
-        xml {
-          source => "xmldata"
-          xpath => [ "/foo/h:div", "xpath_field" ]
-          namespaces => {"h" => "http://www.w3.org/TR/html4/"}
-          remove_namespaces => false
-          store_xml => false
-        }
-      }
-      CONFIG
-
-      # Single value
-      sample("xmldata" => '<foo><h:div xmlns:h="http://www.w3.org/TR/html4/">Content</h:div></foo>') do
-        insist { subject.get("xpath_field") } == ["<h:div xmlns:h=\"http://www.w3.org/TR/html4/\">Content</h:div>"]
-      end
-  end
-
-  describe "parse removing namespaces" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        xpath => [ "/foo/div", "xpath_field" ]
-        remove_namespaces => true
-        store_xml => false
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
-      insist { subject.get("xpath_field") } == ["<div>Content</div>"]
-    end
-  end
-
-
-  describe "parse with forcing array (Default)" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        target => "parseddata"
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("xmldata" => '<foo><bar>Content</bar></foo>') do
-      insist { subject.get("parseddata") } == { "bar" => ["Content"] }
-    end
-  end
-
-  describe "parse disabling forcing array" do
-    config <<-CONFIG
-    filter {
-      xml {
-        source => "xmldata"
-        target => "parseddata"
-        force_array => false
-      }
-    }
-    CONFIG
-
-    # Single value
-    sample("xmldata" => '<foo><bar>Content</bar></foo>') do
-      insist { subject.get("parseddata") } == { "bar" => "Content" }
-    end
-  end
-
-  context "Using suppress_empty option" do
-    describe "suppress_empty => false" do
-      config <<-CONFIG
-      filter {
-        xml {
-          source => "xmldata"
-          target => "data"
-          suppress_empty => false
-        }
-      }
-      CONFIG
-
-      sample("xmldata" => '<foo><key>value1</key><key></key></foo>') do
-        insist { subject.get("tags") }.nil?
-        insist { subject.get("data") } == {"key" => ["value1", {}]}
-      end
-    end
-
-    describe "suppress_empty => true" do
-      config <<-CONFIG
-      filter {
-        xml {
-          source => "xmldata"
-          target => "data"
-          suppress_empty => true
-        }
-      }
-      CONFIG
-
-      sample("xmldata" => '<foo><key>value1</key><key></key></foo>') do
-        insist { subject.get("tags") }.nil?
-        insist { subject.get("data") } == {"key" => ["value1"]}
-      end
-    end
-  end
-
-  context "Using force content option" do
-    describe "force_content => false" do
-      config <<-CONFIG
-      filter {
-        xml {
-          source => "xmldata"
-          target => "data"
-          force_array => false
-          force_content => false
-        }
-      }
-      CONFIG
-
-      sample("xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>') do
-        insist { subject.get("tags") }.nil?
-        insist { subject.get("data") } ==  { 'x' => 'text1', 'y' => { 'a' => '2', 'content' => 'text2' } }
-      end
-    end
-    describe "force_content => true" do
-      config <<-CONFIG
-      filter {
-        xml {
-          source => "xmldata"
-          target => "data"
-          force_array => false
-          force_content => true
-        }
-      }
-      CONFIG
-
-      sample("xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>') do
-        insist { subject.get("tags") }.nil?
-        insist { subject.get("data") } ==  { 'x' => { 'content' => 'text1' }, 'y' => { 'a' => '2', 'content' => 'text2' } }
-      end
-    end
-  end
-
-  describe "plugin registration" do
-    config <<-CONFIG
-    filter {
-      xml {
-        xmldata => "message"
-        store_xml => true
-      }
-    }
-    CONFIG
-
-    sample("xmldata" => "<foo>random message</foo>") do
-      insist { subject }.raises(LogStash::ConfigurationError)
     end
   end
 end


### PR DESCRIPTION
* Improve error handling of xml/xpath parsing
* Minor improvments (see changelog)
* refactor the test file to 
 * reuse xml parsing tests
 * group tests logically (I was lost, must admits)

Here is the current structure of context:
````
philippe@debian:~/dev/wiibaa/logstash-filter-xml$ grep context spec/filters/xml_spec.rb 
  context "ensure xml parsers consistent report of _xmlparsefailure" do
    context "XMLSimple validation" do
    context "Nokogiri validation" do
  context "parse standard xml" do
    context "using formatting options" do
      context "forcing_array" do
      context "suppress_empty" do
      context "force_content" do
  context "executing xpath query on the xml content and storing result in a field" do
    context "standard usage" do
    context "xpath expression configuration" do
    context "namespace handling" do
  context "plugin registration checks" do

````

