### PR TITLE
Bugfix/i18n message name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+  - Fix a bug that, when the plugin tried to report an invalid configuration, would report the following instead of the real error:
+    translation missing: en.logstash.agent.configuration.invalid_plugin_register
+
 ## 4.0.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -104,7 +104,7 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
 
     if @store_xml && (!@target || @target.empty?)
       raise LogStash::ConfigurationError, I18n.t(
-        "logstash.agent.configuration.invalid_plugin_register",
+        "logstash.runner.configuration.invalid_plugin_register",
         :plugin => "filter",
         :type => "xml",
         :error => "When the 'store_xml' configuration option is true, 'target' must also be set"

--- a/logstash-filter-xml.gemspec
+++ b/logstash-filter-xml.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-xml'
-  s.version         = '4.0.1'
+  s.version         = '4.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Takes a field that contains XML and expands it into an actual datastructure."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR fixes an error reporting problem when users have `store_xml` set (default) but omit `target`.