### PR TITLE
Fix missing quote in example

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -82,7 +82,7 @@ filter {
   xml {
     namespaces => {
       "xsl" => "http://www.w3.org/1999/XSL/Transform"
-      "xhtml" => http://www.w3.org/1999/xhtml"
+      "xhtml" => "http://www.w3.org/1999/xhtml"
     }
   }
 }


### PR DESCRIPTION
This PR fix the typo in the newly externalized doc file.

As the doc is still present in the ruby file #38 should be merged for consistency
#41 can be closed as duplicated

@ph an easy 3-in-1