### PR TITLE
Remove the `LogStash::Filters::Xml plugin registration` example

### DIFF
--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -382,19 +382,4 @@ describe LogStash::Filters::Xml do
       end
     end
   end
-
-  describe "plugin registration" do
-    config <<-CONFIG
-    filter {
-      xml {
-        xmldata => "message"
-        store_xml => true
-      }
-    }
-    CONFIG
-
-    sample("xmldata" => "<foo>random message</foo>") do
-      insist { subject }.raises(LogStash::ConfigurationError)
-    end
-  end
 end


### PR DESCRIPTION
The test was testing that the plugin fails the registration when it
received invalid options, the exception was raised before insist could
capture the block. This feature is part of the core api and we should
not test it in plugins.

fixes: #48