### PR TITLE
fix for force_array behavior

### DIFF
--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -148,16 +148,16 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
         return
       end
       doc.remove_namespaces! if @remove_namespaces
-      
-      #Initialize resultset upfront
-      data = event.get(xpath_dest) || []
-      
+            
       @xpath.each do |xpath_src, xpath_dest|
         nodeset = @namespaces.empty? ? doc.xpath(xpath_src) : doc.xpath(xpath_src, @namespaces)
 
         # If asking xpath for a String, like "name(/*)", we get back a
         # String instead of a NodeSet.  We normalize that here.
         normalized_nodeset = nodeset.kind_of?(Nokogiri::XML::NodeSet) ? nodeset : [nodeset]
+        
+        # Initialize empty resultset
+        data = event.get(xpath_dest) || []
 
         normalized_nodeset.each do |value|
           # some XPath functions return empty arrays as string

--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -157,7 +157,7 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
         normalized_nodeset = nodeset.kind_of?(Nokogiri::XML::NodeSet) ? nodeset : [nodeset]
         
         # Initialize empty resultset
-        data = event.get(xpath_dest) || []
+        data = []
 
         normalized_nodeset.each do |value|
           # some XPath functions return empty arrays as string

--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -148,7 +148,10 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
         return
       end
       doc.remove_namespaces! if @remove_namespaces
-
+      
+      #Initialize resultset upfront
+      data = event.get(xpath_dest) || []
+      
       @xpath.each do |xpath_src, xpath_dest|
         nodeset = @namespaces.empty? ? doc.xpath(xpath_src) : doc.xpath(xpath_src, @namespaces)
 
@@ -158,19 +161,19 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
 
         normalized_nodeset.each do |value|
           # some XPath functions return empty arrays as string
-          # TODO: (colin) the return statement here feels like a bug and should probably be a next ?
-          return if value.is_a?(Array) && value.length == 0
+          next if value.is_a?(Array) && value.length == 0
 
           if value
             matched = true
-            # TODO: (colin) this can probably be optimized to avoid the Event get/set at every loop iteration anf
-            # the array should probably be created once, filled in the loop and set at after the loop but the return
-            # statement above screws this strategy and is likely a bug anyway so I will not touch this until I can
-            # deep a big deeper and verify there is a sufficient test harness to refactor this.
-            data = event.get(xpath_dest) || []
             data << value.to_s
-            event.set(xpath_dest, data)
           end
+          
+        end
+        # set the destination attribute, if it's an array with a bigger size than one, leave as is. otherwise make it a string. added force_array param to provide same functionality as writing it in an xml target
+        if data.size == 1 && !@force_array
+          event.set(xpath_dest, data[0])
+        else
+          event.set(xpath_dest, data)
         end
       end
     end


### PR DESCRIPTION
Hi there!

This change fixes #46 
I did not run the test suite, since I didn't have a lot of time on my hands, I did run with my own test data though.

The behavior has been fixed as follows:

- Instead of a return used next to skip the empty array xpath result
- Initialized result array just before the foreach.
- Added force_array behavior as follows:
    - If the result array size is bigger than one, always set as array
    - If the result array is one and force_array => false take the element and add it as a string to the event

feel free to adjust/throw it against the test suite and let me know what you think!