### PR TITLE
Fixed empty event set

### DIFF
--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -173,7 +173,7 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
         if data.size == 1 && !@force_array
           event.set(xpath_dest, data[0])
         else
-          event.set(xpath_dest, data)
+          event.set(xpath_dest, data) unless data.empty?
         end
       end
     end

--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -173,7 +173,7 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
         if data.size == 1 && !@force_array
           event.set(xpath_dest, data[0])
         else
-          event.set(xpath_dest, data) unless data.empty?
+          event.set(xpath_dest, data) unless data.nil? || data.empty? 
         end
       end
     end

--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -401,5 +401,21 @@ describe LogStash::Filters::Xml do
         insist { subject.get("data") } ==  { 'x' => { 'content' => 'text1' }, 'y' => { 'a' => '2', 'content' => 'text2' } }
       end
     end
+    describe "does not set empty array event on failed xpath" do
+      config <<-CONFIG
+      filter {
+        xml {
+          source => "xmldata"
+          target => "data"
+          xpath => [ "//foo/text()","xpath_field" ]
+        }
+      }
+      CONFIG
+
+      sample("raw" => '<foobar></foobar>') do
+        insist { subject.get("tags") }.nil?
+        insist { subject.get("xpath_field")}.nil?
+      end
+    end
   end
 end


### PR DESCRIPTION
This has been bothering me (and likely many other users) since its introduction in https://github.com/logstash-plugins/logstash-filter-xml/pull/57

It used to be that the `event.set(xpath_dest, data)` was protected by existing after the `return if value.is_a?(Array) && value.length == 0` (which is now a `next`) and within the `normalized_nodeset.each` loop

Now, data is initialized and `event.set(xpath_dest, data)` occurs regardless of what happens within the loop. The result is empty event fields being set where in the past, nothing would be set.

The repercussions are pretty significant for anyone relying on xml xpath results for subsequent filter plugins e.g. [geoip](https://github.com/logstash-plugins/logstash-filter-geoip/issues/148)

So far this change has forced me to use methods similar to this literally anytime I dare to use xml and the cost is **unnecessary**.

```conf
ruby {
    code => "event.remove('FieldName') if event.get('[FieldName]').empty?"
}
```

No testing has been been performed on this change (except for the included rspec test which is passing), however given the above explanation the logic is pretty straight forward.
e.g.
```ruby
force_array = false
data = []

if data.size == 1 && !force_array
    puts true
else
    puts false unless data.empty?
end
```
^ shouldn't return anything

Solves https://github.com/logstash-plugins/logstash-filter-xml/issues/61