### PR TITLE
Feat: added parser_options for more control over XML parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+  - Feat: added parser_options for more control over XML parsing [#68](https://github.com/logstash-plugins/logstash-filter-xml/pull/68)
+
 ## 4.0.7
   - Fixed creation of empty arrays when xpath failed [#59](https://github.com/logstash-plugins/logstash-filter-xml/pull/59)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -91,13 +91,14 @@ filter {
 [id="plugins-{type}s-{plugin}-parser_options"]
 ===== `parser_options`
 
-* Value type is <<string,string>>
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
 
 Setting XML parser options allows for more control of the parsing process.
 By default the parser is not strict and thus accepts some invalid content.
 Currently supported options are:
 
- - _strict_ - forces the parser to fail early when content is not valid xml
+ - `strict` - forces the parser to fail early instead of accumulating errors when content is not valid xml.
 
 [id="plugins-{type}s-{plugin}-remove_namespaces"]
 ===== `remove_namespaces` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -94,13 +94,10 @@ filter {
 * Value type is <<string,string>>
 
 Setting XML parser options allows for more control of the parsing process.
-By default the parser is non strict and thus accepts some invalid content.
-Multiple options are separated by a comma (e.g. `'strict,no_warning'`),
-currently supported options are:
+By default the parser is not strict and thus accepts some invalid content.
+Currently supported options are:
 
  - _strict_ - forces the parser to fail early when content is not valid xml
- - _no_warning_ - allows to parse content when there are only warnings
- - _no_error_ - allows to parse content on non fatal parser errors
 
 [id="plugins-{type}s-{plugin}-remove_namespaces"]
 ===== `remove_namespaces` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,6 +34,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-force_array>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-force_content>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-namespaces>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-parser_options>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-remove_namespaces>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-store_xml>> |<<boolean,boolean>>|No
@@ -87,6 +88,19 @@ filter {
   }
 }
 
+[id="plugins-{type}s-{plugin}-parser_options"]
+===== `parser_options`
+
+* Value type is <<string,string>>
+
+Setting XML parser options allows for more control of the parsing process.
+By default the parser is non strict and thus accepts some invalid content.
+Multiple options are separated by a comma (e.g. `'strict,no_warning'`),
+currently supported options are:
+
+ - _strict_ - forces the parser to fail early when content is not valid xml
+ - _no_warning_ - allows to parse content when there are only warnings
+ - _no_error_ - allows to parse content on non fatal parser errors
 
 [id="plugins-{type}s-{plugin}-remove_namespaces"]
 ===== `remove_namespaces` 

--- a/logstash-filter-xml.gemspec
+++ b/logstash-filter-xml.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-xml'
-  s.version         = '4.0.7'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses XML into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -449,6 +449,16 @@ describe LogStash::Filters::Xml do
     subject { described_class.new(options) }
     let(:options) { ({ 'source' => 'xmldata', 'store_xml' => false, 'parse_options' => parse_options }) }
 
+    context 'strict (supported option)' do
+      let(:parse_options) { 'strict' }
+
+      it 'registers filter' do
+        subject.register
+        expect( subject.send(:xml_parse_options) ).
+            to eql Nokogiri::XML::ParseOptions::STRICT
+      end
+    end
+
     context 'valid' do
       let(:parse_options) { 'no_error,NOWARNING' }
 

--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -418,4 +418,53 @@ describe LogStash::Filters::Xml do
       end
     end
   end
+
+  describe "parsing invalid xml" do
+    subject { described_class.new(options) }
+    let(:options) { ({ 'source' => 'xmldata', 'store_xml' => false }) }
+    let(:xmldata) { "<xml> <sample attr='foo' attr=\"bar\"> <invalid> </sample> </xml>" }
+    let(:event) { LogStash::Event.new(data) }
+    let(:data) { { "xmldata" => xmldata } }
+
+    before { subject.register }
+    after { subject.close }
+
+    it 'does not fail (by default)' do
+      subject.filter(event)
+      expect( event.get("tags") ).to be nil
+    end
+
+    context 'strict option' do
+      let(:options) { super.merge({ 'parse_options' => 'strict' }) }
+
+      it 'does fail parsing' do
+        subject.filter(event)
+        expect( event.get("tags") ).to_not be nil
+        expect( event.get("tags") ).to include '_xmlparsefailure'
+      end
+    end
+  end
+
+  describe "parse_options" do
+    subject { described_class.new(options) }
+    let(:options) { ({ 'source' => 'xmldata', 'store_xml' => false, 'parse_options' => parse_options }) }
+
+    context 'valid' do
+      let(:parse_options) { 'no_error,NOWARNING' }
+
+      it 'registers filter' do
+        subject.register
+        expect( subject.send(:xml_parse_options) ).
+            to eql Nokogiri::XML::ParseOptions::NOERROR | Nokogiri::XML::ParseOptions::NOWARNING
+      end
+    end
+
+    context 'invalid' do
+      let(:parse_options) { 'strict,invalid0' }
+
+      it 'fails to register' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, 'unsupported parse option: "invalid0"')
+      end
+    end
+  end
 end


### PR DESCRIPTION
users sometimes throw non valid XML data at this plugin, which is :hankey: but still
in certain cases (e.g. when the document is huge) this could lead to leaks as the parser by default is very forgiving and does not fail on errors but instead tries to build smt out of the provided content really hard.

in those cases internal errors (such as `SAXParseException`) are stored in a list at the native end.
(to be mapped and retrievable as `doc.errors` when parsing completes)

having more control of the parsing process would allow us to fail early instead of piling up errors.

the proposal supports `xml { parse_options => 'strict', ... }` 

resolves https://github.com/logstash-plugins/logstash-filter-xml/issues/66
