### PR TITLE
prevent exceptions from bubbling up and crashing pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.1
+  - Fix: exceptions thrown while handling events no longer crash the pipeline [#73](https://github.com/logstash-plugins/logstash-filter-xml/pull/73)
+
 ## 4.1.0
   - Feat: added parser_options for more control over XML parsing [#68](https://github.com/logstash-plugins/logstash-filter-xml/pull/68)
 

--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -203,6 +203,14 @@ class LogStash::Filters::Xml < LogStash::Filters::Base
 
     filter_matched(event) if matched
     @logger.debug? && @logger.debug("Event after xml filter", :event => event)
+  rescue => e
+    event.tag(XMLPARSEFAILURE_TAG)
+
+    log_payload = { :exception => e.message, :source => @source }
+    log_payload[:value] = value unless value.nil?
+    log_payload[:backtrace] = e.backtrace if @logger.debug?
+
+    @logger.warn("XML Parse Error", log_payload)
   end
 
   private

--- a/logstash-filter-xml.gemspec
+++ b/logstash-filter-xml.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-xml'
-  s.version         = '4.1.0'
+  s.version         = '4.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses XML into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds a catch-all exception handler that prevents exceptions from bubbling up and crashing the pipeline.

When exceptions occur, the event is tagged with the normal `_xmlparsefailure`, and a log warning is emitted with helpful details about the event.