### PR TITLE
Doc: Correct name for parse_options setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.2
+  - [DOC] Updated docs to correct name of parse_options config option [#75](https://github.com/logstash-plugins/logstash-filter-xml/pull/75)
+
 ## 4.1.1
   - Fix: exceptions thrown while handling events no longer crash the pipeline [#73](https://github.com/logstash-plugins/logstash-filter-xml/pull/73)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,7 +34,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-force_array>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-force_content>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-namespaces>> |<<hash,hash>>|No
-| <<plugins-{type}s-{plugin}-parser_options>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-parse_options>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-remove_namespaces>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-store_xml>> |<<boolean,boolean>>|No
@@ -88,13 +88,13 @@ filter {
   }
 }
 
-[id="plugins-{type}s-{plugin}-parser_options"]
-===== `parser_options`
+[id="plugins-{type}s-{plugin}-parse_options"]
+===== `parse_options`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-Setting XML parser options allows for more control of the parsing process.
+Setting XML parse options allows for more control of the parsing process.
 By default the parser is not strict and thus accepts some invalid content.
 Currently supported options are:
 

--- a/logstash-filter-xml.gemspec
+++ b/logstash-filter-xml.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-xml'
-  s.version         = '4.1.1'
+  s.version         = '4.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses XML into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Doc change based on a post-merge comment: https://github.com/logstash-plugins/logstash-filter-xml/pull/68#issuecomment-866381266

Looking at https://github.com/logstash-plugins/logstash-filter-xml/blob/master/lib/logstash/filters/xml.rb, this suggestion appears to be correct.  Please keep me honest, @kares  😄 
