### PR TITLE
Fix dictionary definition passed into the spec methods

### DIFF
--- a/spec/filters/xml_spec.rb
+++ b/spec/filters/xml_spec.rb
@@ -15,55 +15,55 @@ describe LogStash::Filters::Xml do
     }
     CONFIG
 
-    sample("raw" => '<foo key="value"/>') do
+    sample({"raw" => '<foo key="value"/>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data")} == {"key" => "value"}
     end
 
     #From parse xml with array as a value
-    sample("raw" => '<foo><key>value1</key><key>value2</key></foo>') do
+    sample({"raw" => '<foo><key>value1</key><key>value2</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data")} == {"key" => ["value1", "value2"]}
     end
 
     #From parse xml with hash as a value
-    sample("raw" => '<foo><key1><key2>value</key2></key1></foo>') do
+    sample({"raw" => '<foo><key1><key2>value</key2></key1></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data")} == {"key1" => [{"key2" => ["value"]}]}
     end
 
     # parse xml in single item array
-    sample("raw" => ["<foo bar=\"baz\"/>"]) do
+    sample({"raw" => ["<foo bar=\"baz\"/>"]}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data")} == {"bar" => "baz"}
     end
 
     # fail in multi items array
-    sample("raw" => ["<foo bar=\"baz\"/>", "jojoba"]) do
+    sample({"raw" => ["<foo bar=\"baz\"/>", "jojoba"]}) do
       insist { subject.get("tags") }.include?("_xmlparsefailure")
       insist { subject.get("data")} == nil
     end
 
     # fail in empty array
-    sample("raw" => []) do
+    sample({"raw" => []}) do
       insist { subject.get("tags") }.include?("_xmlparsefailure")
       insist { subject.get("data")} == nil
     end
 
     # fail for non string field
-    sample("raw" => {"foo" => "bar"}) do
+    sample({"raw" => {"foo" => "bar"}}) do
       insist { subject.get("tags") }.include?("_xmlparsefailure")
       insist { subject.get("data")} == nil
     end
 
     # fail for non string single item array
-    sample("raw" => [{"foo" => "bar"}]) do
+    sample({"raw" => [{"foo" => "bar"}]}) do
       insist { subject.get("tags") }.include?("_xmlparsefailure")
       insist { subject.get("data")} == nil
     end
 
     #From bad xml
-    sample("raw" => '<foo /') do
+    sample({"raw" => '<foo /'}) do
       insist { subject.get("tags") }.include?("_xmlparsefailure")
     end
   end
@@ -79,7 +79,7 @@ describe LogStash::Filters::Xml do
     }
     CONFIG
 
-    sample("raw" => '<foo key="value"/>') do
+    sample({"raw" => '<foo key="value"/>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data")} == nil
     end
@@ -97,13 +97,13 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("raw" => '<foo><key>value</key></foo>') do
+    sample({"raw" => '<foo><key>value</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("xpath_field")} == ["value"]
     end
 
     #Multiple values
-    sample("raw" => '<foo><key>value1</key><key>value2</key></foo>') do
+    sample({"raw" => '<foo><key>value1</key><key>value2</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("xpath_field")} == ["value1","value2"]
     end
@@ -121,25 +121,25 @@ describe LogStash::Filters::Xml do
     }
     CONFIG
 
-    sample("xmldata" => '<foo key="value"/>') do
+    sample({"xmldata" => '<foo key="value"/>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data") } == {"key" => "value"}
     end
 
     #From parse xml with array as a value
-    sample("xmldata" => '<foo><key>value1</key><key>value2</key></foo>') do
+    sample({"xmldata" => '<foo><key>value1</key><key>value2</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data") } == {"key" => ["value1", "value2"]}
     end
 
     #From parse xml with hash as a value
-    sample("xmldata" => '<foo><key1><key2>value</key2></key1></foo>') do
+    sample({"xmldata" => '<foo><key1><key2>value</key2></key1></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data") } == {"key1" => [{"key2" => ["value"]}]}
     end
 
     #From bad xml
-    sample("xmldata" => '<foo /') do
+    sample({"xmldata" => '<foo /'}) do
       insist { subject.get("tags") }.include?("_xmlparsefailure")
     end
   end
@@ -155,7 +155,7 @@ describe LogStash::Filters::Xml do
     }
     CONFIG
 
-    sample("xmldata" => '<foo key="value"/>') do
+    sample({"xmldata" => '<foo key="value"/>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("data")} == nil
     end
@@ -173,13 +173,13 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<foo><key>value</key></foo>') do
+    sample({"xmldata" => '<foo><key>value</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("xpath_field") } == ["value"]
     end
 
     #Multiple values
-    sample("xmldata" => '<foo><key>value1</key><key>value2</key></foo>') do
+    sample({"xmldata" => '<foo><key>value1</key><key>value2</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("xpath_field") } == ["value1","value2"]
     end
@@ -197,7 +197,7 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<foo><key>Français</key></foo>') do
+    sample({"xmldata" => '<foo><key>Français</key></foo>'}) do
       insist { subject.get("tags") }.nil?
       insist { subject.get("xpath_field")} == ["Français"]
     end
@@ -216,7 +216,7 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
+    sample({"xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>'}) do
       insist { subject.get("xpath_field") } == ["<h:div>Content</h:div>"]
     end
   end
@@ -235,7 +235,7 @@ describe LogStash::Filters::Xml do
       CONFIG
 
       # Single value
-      sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
+      sample({"xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>'}) do
         insist { subject.get("xpath_field") } == ["<h:div>Content</h:div>"]
       end
   end
@@ -254,7 +254,7 @@ describe LogStash::Filters::Xml do
       CONFIG
 
       # Single value
-      sample("xmldata" => '<foo><h:div xmlns:h="http://www.w3.org/TR/html4/">Content</h:div></foo>') do
+      sample({"xmldata" => '<foo><h:div xmlns:h="http://www.w3.org/TR/html4/">Content</h:div></foo>'}) do
         insist { subject.get("xpath_field") } == ["<h:div xmlns:h=\"http://www.w3.org/TR/html4/\">Content</h:div>"]
       end
   end
@@ -272,7 +272,7 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>') do
+    sample({"xmldata" => '<foo xmlns:h="http://www.w3.org/TR/html4/"><h:div>Content</h:div></foo>'}) do
       insist { subject.get("xpath_field") } == ["<div>Content</div>"]
     end
   end
@@ -289,7 +289,7 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<foo><bar>Content</bar></foo>') do
+    sample({"xmldata" => '<foo><bar>Content</bar></foo>'}) do
       insist { subject.get("parseddata") } == { "bar" => ["Content"] }
     end
   end
@@ -306,7 +306,7 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<foo><bar>Content</bar></foo>') do
+    sample({"xmldata" => '<foo><bar>Content</bar></foo>'}) do
       insist { subject.get("parseddata") } == { "bar" => "Content" }
     end
   end
@@ -326,7 +326,7 @@ describe LogStash::Filters::Xml do
     CONFIG
 
     # Single value
-    sample("xmldata" => '<element><field1>bbb</field1><field2>789</field2><field3>e3f<field3></element>') do
+    sample({"xmldata" => '<element><field1>bbb</field1><field2>789</field2><field3>e3f<field3></element>'}) do
       insist { subject.get("field1") } == "bbb"
     end
   end
@@ -343,7 +343,7 @@ describe LogStash::Filters::Xml do
       }
       CONFIG
 
-      sample("xmldata" => '<foo><key>value1</key><key></key></foo>') do
+      sample({"xmldata" => '<foo><key>value1</key><key></key></foo>'}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("data") } == {"key" => ["value1", {}]}
       end
@@ -360,7 +360,7 @@ describe LogStash::Filters::Xml do
       }
       CONFIG
 
-      sample("xmldata" => '<foo><key>value1</key><key></key></foo>') do
+      sample({"xmldata" => '<foo><key>value1</key><key></key></foo>'}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("data") } == {"key" => ["value1"]}
       end
@@ -380,7 +380,7 @@ describe LogStash::Filters::Xml do
       }
       CONFIG
 
-      sample("xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>') do
+      sample({"xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>'}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("data") } ==  { 'x' => 'text1', 'y' => { 'a' => '2', 'content' => 'text2' } }
       end
@@ -397,7 +397,7 @@ describe LogStash::Filters::Xml do
       }
       CONFIG
 
-      sample("xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>') do
+      sample({"xmldata" => '<opt><x>text1</x><y a="2">text2</y></opt>'}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("data") } ==  { 'x' => { 'content' => 'text1' }, 'y' => { 'a' => '2', 'content' => 'text2' } }
       end
@@ -413,7 +413,7 @@ describe LogStash::Filters::Xml do
       }
       CONFIG
 
-      sample("raw" => '<foobar></foobar>') do
+      sample({"raw" => '<foobar></foobar>'}) do
         insist { subject.get("tags") }.nil?
         insist { subject.get("xpath_field")}.nil?
       end


### PR DESCRIPTION
Fix dictionary definition passed into the spec methods, to be compliant with JRuby 9.4

## How to test
Same steps as https://github.com/logstash-plugins/logstash-filter-cidr/pull/26
