### PR TITLE
patch rexml to improve performance of multi-threaded xml parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ import:
 env:
   jobs:
     # lock on version 8.x because use Ruby 2.6.0 available from 8.4.0
-    - ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env
+    - ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.2.1
-  - TODO
+  - patch rexml to improve performance of multi-threaded xml parsing [#84](https://github.com/logstash-plugins/logstash-filter-xml/pull/84)
+#84
 
 ## 4.2.0
   - Update Nokogiri dependency version [#78](https://github.com/logstash-plugins/logstash-filter-xml/pull/78)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.1
+  - TODO
+
 ## 4.2.0
   - Update Nokogiri dependency version [#78](https://github.com/logstash-plugins/logstash-filter-xml/pull/78)
 

--- a/lib/logstash/filters/xml.rb
+++ b/lib/logstash/filters/xml.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/filters/xml/patch_rexml"
 
 # XML filter. Takes a field that contains XML and expands it into
 # an actual datastructure.

--- a/lib/logstash/filters/xml/patch_rexml.rb
+++ b/lib/logstash/filters/xml/patch_rexml.rb
@@ -1,0 +1,27 @@
+require 'xmlsimple'
+require 'stringio'
+
+module REXML
+  class SourceFactory
+    # Generates a Source object
+    # @param arg Either a String, or an IO
+    # @return a Source, or nil if a bad argument was given
+    def SourceFactory::create_from(arg)
+      if arg.respond_to? :read and
+          arg.respond_to? :readline and
+          arg.respond_to? :nil? and
+          arg.respond_to? :eof?
+        IOSource.new(arg)
+      elsif arg.respond_to? :to_str
+        # remove this require to speed up multi-threaded parsing
+        #require 'stringio'
+        IOSource.new(StringIO.new(arg))
+      elsif arg.kind_of? Source
+        arg
+      else
+        raise "#{arg.class} is not a valid input stream.  It must walk \n"+
+          "like either a String, an IO, or a Source."
+      end
+    end
+  end
+end

--- a/logstash-filter-xml.gemspec
+++ b/logstash-filter-xml.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-xml'
-  s.version         = '4.2.0'
+  s.version         = '4.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses XML into fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This change monkey patches the `SourceFactory::create_from` method from rexml to not require 'stringio'. This is done by copying that method to this plugin and moving the require call to the top.

To check the performance improvement. Before:

```
❯ time bin/logstash -e 'input { java_generator { message => "<root> <item>&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;</item> <item>&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;</item> <item>&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;</item> <item>&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;</item> <item>&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;</item> <item>&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;</item> </root>" count => 100000 } } filter { xml { target => target source => message } } output { null {} }' --log.level=error
Using bundled JDK: /tmp/test/logstash-8.15.3.slow/jdk.app/Contents/Home
Sending Logstash logs to /tmp/test/logstash-8.15.3.slow/logs which is now configured via log4j2.properties
bin/logstash -e  --log.level=error  100.31s user 25.54s system 242% cpu 51.794 total
```

After:

```
❯ time bin/logstash -e 'input { java_generator { message => "<root> <item>&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;&#x1111;</item> <item>&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;&#x2222;</item> <item>&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;&#x3333;</item> <item>&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;&#x4444;</item> <item>&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;&#x5555;</item> <item>&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;&#x6666;</item> </root>" count => 100000 } } filter { xml { target => target source => message } } output { null {} }' --log.level=error
Using bundled JDK: /tmp/test/logstash-8.15.3.fast/jdk.app/Contents/Home
Sending Logstash logs to /tmp/test/logstash-8.15.3.fast/logs which is now configured via log4j2.properties
bin/logstash -e  --log.level=error  121.21s user 2.96s system 682% cpu 18.194 total
```

closes #83